### PR TITLE
Fix soldiers moving backward when out of range

### DIFF
--- a/main_game.html
+++ b/main_game.html
@@ -234,7 +234,11 @@
         if (!best) return; // no targets
         this.lookAt(best.mesh.position);
         if (bd <= this.range) { if (this.cooldown <= 0) this.fireAt(best); else this.cooldown -= dt; }
-        else { const step = Math.min(0.0, this.range - bd); if (step !== 0) this.mesh.position.addInPlace(this.mesh.forward.scale(step*dt)); this.cooldown -= dt; }
+        else {
+          const step = Math.max(0.0, bd - this.range);
+          if (step !== 0) this.mesh.position.addInPlace(this.mesh.forward.scale(step * dt));
+          this.cooldown -= dt;
+        }
       }
       applyRally(duration=8, rofMult=1.3, accMult=1.18){ this.buffTimer = Math.max(this.buffTimer, duration); this.buffRofMult = Math.max(this.buffRofMult, rofMult); this.buffAccMult = Math.max(this.buffAccMult, accMult); }
       tryInstantFire(enemies){ if (!this.alive) return; if (this.cooldown > 0.2) return; let best = null; let bd = 9999; for (const e of enemies) { if (!e.alive) continue; const d = BABYLON.Vector3.Distance(this.mesh.position, e.mesh.position); if (d < bd) { bd = d; best = e; } } if (best && bd <= this.range) this.fireAt(best); }


### PR DESCRIPTION
## Summary
- Correct soldier movement logic so units advance toward enemies when outside firing range

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a17eaa21e88333830f9854f6e3e70a